### PR TITLE
Change args parameter to symbol.

### DIFF
--- a/lib/contactually.rb
+++ b/lib/contactually.rb
@@ -69,7 +69,7 @@ module Contactually
     end
 
     def build_uri(contactually_method, args = {})
-      id_arg = args.has_key?(:id) ? "/#{args["id"]}" : ""
+      id_arg = args.has_key?(:id) ? "/#{args[:id]}" : ""
       "https://www.contactually.com/api/v1/#{contactually_method}#{id_arg}.json?api_key=#{@api_key}"
     end
 


### PR DESCRIPTION
Please review small code change that will allow us to pass "minimal_index" as a parameter in the call to contactually.  It turns out that a call to 
https://www.contactually.com/api/v1/groupings.json
does not give us all buckets and tags for an account but 
https://www.contactually.com/api/v1/groupings/minimal_index.json
does.

**Thank you!!**
